### PR TITLE
Bump Hugo and Azure CLI Versions in Workflow

### DIFF
--- a/.github/workflows/site-deployment.yaml
+++ b/.github/workflows/site-deployment.yaml
@@ -1,4 +1,3 @@
-# Another dummy
 name: Azure Static Web Apps CI/CD
 
 # This GitHub Action workflow triggers in two scenarios - 

--- a/content/person/johnkilmister/index.md
+++ b/content/person/johnkilmister/index.md
@@ -6,7 +6,7 @@ Instagram: ""
 Linkedin: "johnkilmister"
 Pinterest: ""
 image: images/johnkilmister.jpg
-Title: John Kilminster
+Title: John Kilmister
 Twitter: "johnkilmister"
 Website: ""
 YouTube: ""


### PR DESCRIPTION
# Description

Several chores -

- Update to hugo v0.102.3
- Update to Azure CLI v2.40.0

# Schedule

No special requirements

## Type of change

Please delete options that are not rel

- [X] Admin / Chore

# Checklist:

- [X] My code follows the style guidelines of this project, by meeting any linting requirements
- [X] I have the right to publish this content
- [X] All images have used in markdown are referenced with a description, as well as a caption (The format would be ``![Description](path/to/image.jpg "Caption")``).